### PR TITLE
Remove dependabot for integration submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - commit-message:
-      prefix: "Changelog:All"
-    directory: /
-    package-ecosystem: gitsubmodule
-    schedule:
-      interval: weekly
-


### PR DESCRIPTION
We will update the test framework ad-hoc when new tests require it.