### PR TITLE
Fix integration tests

### DIFF
--- a/tests/integration/tests/test_mender_configure.py
+++ b/tests/integration/tests/test_mender_configure.py
@@ -190,6 +190,12 @@ def test_mender_configure_failed_install_config_is_a_folder(
     # Install a no-op configuration apply script
     make_configuration_apply_script(setup_tester_ssh_connection, "#/bin/sh\nexit 0\n")
 
+    # Remove the configuration file if it exists
+    run(
+        setup_tester_ssh_connection,
+        "rm -f /var/lib/mender-configure/device-config.json",
+    )
+
     # Lock the configuration file with a folder
     run(
         setup_tester_ssh_connection,

--- a/tests/integration/tests/test_timezone.py
+++ b/tests/integration/tests/test_timezone.py
@@ -21,6 +21,7 @@ from mender_test_containers.helpers import run, put
 
 def test_timezone_script(setup_test_container, setup_tester_ssh_connection):
     run(setup_tester_ssh_connection, "mount / -o remount,rw")
+    run(setup_tester_ssh_connection, "systemctl restart systemd-timedated")
 
     try:
         run(
@@ -64,5 +65,5 @@ def test_timezone_script(setup_test_container, setup_tester_ssh_connection):
         assert abs(int(new_hour) - int(old_hour)) > 5
 
     finally:
-        run(setup_tester_ssh_connection, "timedatectl set-timezone UTC")
+        run(setup_tester_ssh_connection, "timedatectl set-timezone UTC || true")
         run(setup_tester_ssh_connection, "mount / -o remount,ro")


### PR DESCRIPTION
The mendersoftware/mender-client-qemu-rofs client provides a default
configuration file which needs to be removed when running the test
which locks the config file with a folder.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>