### PR TITLE
use gitlab native triggers to trigger pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,9 +19,9 @@ variables:
 test:unit:
   stage: test
   needs: []
-  image: alpine:latest
+  image: python:alpine
   before_script:
-    - apk add --update git make curl python3
+    - apk add --update git make curl
     - git submodule update --init --recursive
   script:
     - make test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,6 @@ test:integration:
 trigger:mender-dist-packages:
   stage: trigger
   rules:
-    - if: $CI_COMMIT_TAG
     - if: '$CI_COMMIT_BRANCH == "master"'
   trigger:
     project: Northern.tech/Mender/mender-dist-packages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ include:
 variables:
   MENDER_VERSION: master
   MENDER_ARTIFACT_VERSION: master
+  MENDER_CONFIGURE_VERSION: $CI_COMMIT_REF_NAME
 
 test:unit:
   stage: test
@@ -63,29 +64,20 @@ test:integration:
     - ./run.sh
 
 trigger:mender-dist-packages:
-  image: alpine
   stage: trigger
-  before_script:
-    - apk add --no-cache curl
-  script:
-    - curl -v -f -X POST
-      -F token=$MENDER_DIST_PACKAGES_TRIGGER_TOKEN
-      -F ref=master
-      -F variables[MENDER_CONFIGURE_VERSION]=$CI_COMMIT_REF_NAME
-      https://gitlab.com/api/v4/projects/14968223/trigger/pipeline
-  only:
-    - tags
-    - master
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_BRANCH == "master"'
+  trigger:
+    project: Northern.tech/Mender/mender-dist-packages
+    branch: master
+    strategy: depend
 
 trigger:integration:
-  image: alpine
   stage: trigger
-  before_script:
-    - apk add --no-cache curl
-  script:
-    - curl -v -f -X POST
-      -F token=$CI_TRIGGER_TOKEN_INTEGRATION
-      -F ref=master
-      https://gitlab.com/api/v4/projects/12670314/trigger/pipeline
-  only:
-    - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
+  trigger:
+    project: Northern.tech/Mender/integration
+    branch: master
+    strategy: depend


### PR DESCRIPTION
Since I needed a multi-staged, multi-project pipeline (and had an faulty understanding of the mender-dist-packages repo) and worked on these parts anyway for QA-315, I followed the boy scout rule and aligned the trigger usage with the now available gitlab functionality.

  triggering pipeline: https://gitlab.com/Northern.tech/Mender/mender-configure-module/-/pipelines/314985128
  triggered pipelines:
   - [integration](https://gitlab.com/Northern.tech/Mender/integration/-/pipelines/314991278)
   - [mender-dist-packages](https://gitlab.com/Northern.tech/Mender/mender-dist-packages/-/pipelines/314991260)
