### PR TITLE
MEN-4769: include the current JWT token in the reported config checksum

### DIFF
--- a/src/mender-inventory-mender-configure
+++ b/src/mender-inventory-mender-configure
@@ -29,13 +29,6 @@ if ! [ -f "$CONFIG" ]; then
     exit 0
 fi
 
-COMPUTED_CHECKSUM="$(cat "$CONFIG" | sha256sum -)"
-
-if [ -f "$CONFIG_CHECKSUM" ] && [ "$COMPUTED_CHECKSUM" = "$(cat "$CONFIG_CHECKSUM")" ]; then
-    # If checksum hasn't changed since previous report, exit silently.
-    exit 0
-fi
-
 # Fetch Authentication token and server from Mender Auth Manager.
 DBUS_REPLY="$(dbus-send \
                         --system \
@@ -55,6 +48,16 @@ fi
 if [ -z "$SERVER" ]; then
     echo "A server address could not be obtained over DBus."
     exit 1
+fi
+
+# Include the JWT token in the checksum to report again the
+# configuration to the server in case of new authorization after
+# device decommissioning or connection to a different Mender server
+COMPUTED_CHECKSUM="$( (echo "$AUTH_TOKEN"; cat "$CONFIG") | sha256sum -)"
+
+# If checksum hasn't changed since previous report, exit silently.
+if [ -f "$CONFIG_CHECKSUM" ] && [ "$COMPUTED_CHECKSUM" = "$(cat "$CONFIG_CHECKSUM")" ]; then
+    exit 0
 fi
 
 # Do the report.

--- a/tests/unit/helpers/mender-configure-server.py
+++ b/tests/unit/helpers/mender-configure-server.py
@@ -23,7 +23,7 @@ class MenderConfigureHandler(server.BaseHTTPRequestHandler):
 
         if self.path != "/api/devices/v1/deviceconfig/configuration":
             response = 404
-        elif auth != "Bearer ThisIsAnAuthToken":
+        elif auth not in ("Bearer ThisIsAnAuthToken", "Bearer ThisIsAnotherAuthToken"):
             response = 401
         else:
             response = 204

--- a/tests/unit/test_inventory.sh
+++ b/tests/unit/test_inventory.sh
@@ -122,6 +122,17 @@ Log: path = "/api/devices/v1/deviceconfig/configuration", auth_token = "Bearer T
     # But no third report.
     assertEquals 'Log: path = "/api/devices/v1/deviceconfig/configuration", auth_token = "Bearer ThisIsAnAuthToken"
 Log: path = "/api/devices/v1/deviceconfig/configuration", auth_token = "Bearer ThisIsAnAuthToken"' "$(cat "$TEST_HTTP_LOG")"
+
+    # Change the auth token
+    export TEST_AUTH_TOKEN="ThisIsAnotherAuthToken"
+
+    output="$("${inv_script}")"
+    assertEquals 0 $?
+    assertEquals "" "${output}"
+    # Now there should be a third report.
+    assertEquals 'Log: path = "/api/devices/v1/deviceconfig/configuration", auth_token = "Bearer ThisIsAnAuthToken"
+Log: path = "/api/devices/v1/deviceconfig/configuration", auth_token = "Bearer ThisIsAnAuthToken"
+Log: path = "/api/devices/v1/deviceconfig/configuration", auth_token = "Bearer ThisIsAnotherAuthToken"' "$(cat "$TEST_HTTP_LOG")"
 }
 
 


### PR DESCRIPTION
Including the current JWT token in the reported config checksum makes
sure the mender-configure addon reports the configuration to the server
in case of a new authorization. This covers a corner case: without this
change, if the device gets decommissioned in the server, then accepted
again, the server will assign a new device ID to it, but no
configuration will be reported until new values are deployed to it.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>