### PR TITLE
Revert "removed mender-dist-packages triggering for tagged builds"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,6 +66,7 @@ test:integration:
 trigger:mender-dist-packages:
   stage: trigger
   rules:
+    - if: $CI_COMMIT_TAG
     - if: '$CI_COMMIT_BRANCH == "master"'
   trigger:
     project: Northern.tech/Mender/mender-dist-packages


### PR DESCRIPTION
This reverts commit 0a5d64c4da5695f3ed71b5cdb180462cef4466a0.

For this specific repository we need to keep it, because
mender-configure-module is not part of the standard Mender release, so
the versions are not set in mender-qa at the time of starting the build.

We have plans to correct this in the future, but for now we need to
trigger the package build from here.