### PR TITLE
MEN-4949: Disable the curl progress bar

### DIFF
--- a/src/mender-inventory-mender-configure
+++ b/src/mender-inventory-mender-configure
@@ -62,6 +62,8 @@ fi
 
 # Do the report.
 curl \
+    -s \
+    -S \
     -Lf \
     -X PUT \
     -H "Authorization: Bearer ${AUTH_TOKEN}" \


### PR DESCRIPTION
The curl progress bar does not play nice when not used in connection with a tty.
Add in the unbuffered nature of stderr, and this is what you get in the client
logs:

```
time="2021-08-13T08:36:57Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\":  "
time="2021-08-13T08:36:57Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\":  "
time="2021-08-13T08:36:57Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\": %"
time="2021-08-13T08:36:57Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\":  "
time="2021-08-13T08:36:57Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\": T"
```

With regular output it behaves though:

```
time="2021-08-13T08:36:57Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-geo\": wget: note: TLS certificate validation not implemented"
```

So, simply disabling the progress report in curl with the `--silent` option will
solve this error.

This will allow us to use the changes applied in
https://github.com/mendersoftware/mender/commit/8c672c35290a1dae9021a29264365ddb39a0300f
without any issues.

Changelog: Mute the `curl` request progress bar in the
`mender-inventory-mender-monitor` script.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit 47083010c3e9f7f533912ec393d61329cb16c622)
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>