### PR TITLE
MEN-5088: Buffer the output from curl, and output it in one go

### DIFF
--- a/src/mender-inventory-mender-configure
+++ b/src/mender-inventory-mender-configure
@@ -60,7 +60,10 @@ if [ -f "$CONFIG_CHECKSUM" ] && [ "$COMPUTED_CHECKSUM" = "$(cat "$CONFIG_CHECKSU
     exit 0
 fi
 
+CAPTURED_CURL_OUTPUT=$(mktemp)
 # Do the report.
+set +e
+{
 curl \
     -s \
     -S \
@@ -70,6 +73,15 @@ curl \
     -H "Content-Type: application/json" \
     -d "@${CONFIG}" \
     "${SERVER}/${CONFIG_ENDPOINT}"
+} > ${CAPTURED_CURL_OUTPUT} 2>&1
+ret=$?
+set -e
+
+cat ${CAPTURED_CURL_OUTPUT}
+rm -f ${CAPTURED_CURL_OUTPUT}
+if [ ${ret} -ne 0 ]; then
+    exit ${ret}
+fi
 
 # Update checksum atomically.
 echo "$COMPUTED_CHECKSUM" > "$CONFIG_CHECKSUM.tmp"


### PR DESCRIPTION
Changelog: Buffer the output from curl in order to prevent the logs in the
Mender client being flooded by one line characters, since curl does not play
nice with the output on stderr.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>