### PR TITLE
QA-347: trigger:mender-dist-packages: Set correct variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,6 +73,9 @@ trigger:mender-dist-packages:
   rules:
     - if: $CI_COMMIT_TAG
     - if: '$CI_COMMIT_BRANCH == "master"'
+  variables:
+    MENDER_CONFIGURE_VERSION: $CI_COMMIT_REF_NAME
+    PUBLISH_MENDER_DIST_PACKAGES_AUTOMATIC: "true"
   trigger:
     project: Northern.tech/Mender/mender-dist-packages
     branch: master


### PR DESCRIPTION
To trigger the publish of packages in experimental distribution

Also, add MENDER_CONFIGURE_VERSION which was missing (!!). This would
have prevented the next mender-configure-module tag to be correctly
published. Fortunately all releases so far are in 1.0.x branch which
does not have this mistake.