### PR TITLE
QA-507: ci: Pin integration tests base image to Alpine 3.16

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,8 @@ test:unit:
 test:integration:
   stage: test
   needs: []
-  image: docker:dind
+  # QA-507: Pin to Alpine 3.16 to have OpenSSL 1.1 compatibility while we redesign this dependency
+  image: docker:20.10.21-dind-alpine3.16
   tags:
     - mender-qa-worker-backend-integration-tests
   before_script:


### PR DESCRIPTION
To workaround the issue with openssl 3 upgrade in latest Alpine.

We are working on a plan to upgrade the whole ecosystem, but meanwhile we need to pin these jobs to older Alpine to keep CI running.