### PR TITLE
Improve timezone script reliability

### DIFF
--- a/scripts/timezone
+++ b/scripts/timezone
@@ -32,7 +32,13 @@ TIMEZONE="$(jq -r -e .timezone < "$CONFIG")"
 return_code=$?
 case $return_code in
     0)
-        timedatectl set-timezone "$TIMEZONE"
+        # Add new timezone
+        echo $TIMEZONE >/etc/timezone
+        # Remove existing symlink between localtime and timezone definition
+        rm /etc/localtime
+        # Reload local time as per /etc/timezone file and
+        # create a symlink to a new timezone definition
+        dpkg-reconfigure -f noninteractive tzdata
         exit $?
         ;;
     1)


### PR DESCRIPTION
During our prototyping of the implementation, we had a play with this script and discovered some misbehaviours.

1. timedatectl sporadically failed with Access denied, generally on first attempt of running the command, even manually, even as root, and starts working as of the second attempt.
2. The timezone in `/etc/timezone` gets changed but the timezone in `/etc/localtime` does not. As a result, `date` is not outputting the right time. Rebooting also reverts the change.

The PR changes the approach and gets it in sync with what `raspi-config` does behind the scenes. Code can be found here: https://github.com/raspberrypi-ui/rc_gui/blob/900e186ef592692122296f6d13fb1c9394bcf2bc/src/rc_gui.c#L934

I will also open a PR into the docs which i will cross-link

Not sure if this script is referenced anywhere else (your apt repository?) that requires updating