### PR TITLE
chore: Revert "Group `dependabot` updates for git submodules"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,5 @@ updates:
     package-ecosystem: gitsubmodule
     schedule:
       interval: monthly
-    groups:
-      gitsubmodule-dependencies:
-        patterns:
-          - "*"
     reviewers:
       - "mendersoftware/client-dependabot-reviewers"


### PR DESCRIPTION
This reverts commit 131d85f39bbe461fbd48fbce1cf29e481b935ada.

It was a nice try, but the very first attempt to combine `integration` and `mender-test-containers` submodules updates failed. As the dependencies updater responsible, I changed my mind.