### PR TITLE
MEN-8591

### DIFF
--- a/src/mender-inventory-mender-configure
+++ b/src/mender-inventory-mender-configure
@@ -42,11 +42,11 @@ AUTH_TOKEN="$(echo "$DBUS_REPLY" | sed -ne '1p')"
 SERVER="$(echo "$DBUS_REPLY" | sed -ne '2p')"
 
 if [ -z "$AUTH_TOKEN" ]; then
-    echo "An authentication token could not be obtained over DBus."
+    echo "mender-inventory-mender-configure: An authentication token could not be obtained over DBus."
     exit 1
 fi
 if [ -z "$SERVER" ]; then
-    echo "A server address could not be obtained over DBus."
+    echo "mender-inventory-mender-configure: A server address could not be obtained over DBus."
     exit 1
 fi
 

--- a/src/mender-inventory-mender-configure
+++ b/src/mender-inventory-mender-configure
@@ -30,13 +30,14 @@ if ! [ -f "$CONFIG" ]; then
 fi
 
 # Fetch Authentication token and server from Mender Auth Manager.
-DBUS_REPLY="$(dbus-send \
-                        --system \
-                        --print-reply \
-                        --dest=io.mender.AuthenticationManager \
-                        /io/mender/AuthenticationManager \
-                        io.mender.Authentication1.GetJwtToken \
-                        | sed -ne '/^ *string ".*" *$/ {s/^ *string "\(.*\)" *$/\1/; p}')"
+DBUS_RAW=$(dbus-send \
+    --system \
+    --print-reply \
+    --dest=io.mender.AuthenticationManager \
+    /io/mender/AuthenticationManager \
+    io.mender.Authentication1.GetJwtToken)
+
+DBUS_REPLY=$(echo "$DBUS_RAW" | sed -ne '/^ *string ".*" *$/ {s/^ *string "\(.*\)" *$/\1/; p}')
 
 AUTH_TOKEN="$(echo "$DBUS_REPLY" | sed -ne '1p')"
 SERVER="$(echo "$DBUS_REPLY" | sed -ne '2p')"

--- a/src/mender-inventory-mender-configure
+++ b/src/mender-inventory-mender-configure
@@ -44,7 +44,9 @@ SERVER="$(echo "$DBUS_REPLY" | sed -ne '2p')"
 
 if [ -z "$AUTH_TOKEN" ]; then
     echo "mender-inventory-mender-configure: An authentication token could not be obtained over DBus."
-    exit 1
+    # Don't produce an error. Most likely mender-auth is not ready or
+    # the device hasn't been accepted
+    exit 0
 fi
 if [ -z "$SERVER" ]; then
     echo "mender-inventory-mender-configure: A server address could not be obtained over DBus."

--- a/tests/unit/test_inventory.sh
+++ b/tests/unit/test_inventory.sh
@@ -76,7 +76,7 @@ testInvalidEndpoint() {
 testMissingJwtToken() {
     export TEST_AUTH_TOKEN_EMPTY=1
     output="$("${inv_script}")"
-    assertNotEquals 0 $?
+    assertEquals 0 $?
     assertEquals "" "${output}"
     assertEquals "" "$(cat "$TEST_HTTP_LOG" 2>/dev/null)"
 }


### PR DESCRIPTION
I decided to keep the `An authentication token could not be obtained over DBus.` for verbosity, so I opted to change the exit code to 0